### PR TITLE
API cleanup and compatibility fixes + README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,43 +5,94 @@ Attach metadata to users.
 
 ## Configuration
 
- * `REDIS_AUTH_PORT_6379_TCP_ADDR`
- * `REDIS_AUTH_PORT_6379_TCP_PORT`
- * `REDIS_USERMETA_PORT_6379_TCP_ADDR`
- * `REDIS_USERMETA_PORT_6379_TCP_PORT`
- * `USERMETA_VALID_KEYS`
-   * A comma-separated list of keys, restricting valid metadata keys.
-   * _optional_
+ * `API_SECRET` — secret to compare to for internal access level
+ * keys (all are required, pass empty string for `[]`):
+   * `USERMETA_PUBLIC_KEYS` — comma-separated list of keys (public read, token write)
+   * `USERMETA_PROTECTED_KEYS` — comma-separated list of keys (token read, token write)
+   * `USERMETA_PRIVATE_KEYS` — comma-separated list of keys (token read, secret write)
+   * `USERMETA_INTERNAL_KEYS` — comma-separated list of keys (secret read, secret write)
+   * `USERMETA_MAX_LENGTH` (optional, default `200`) — max byte length of token-writable keys (those that don't require API_SECRET to be written)
+ * `REDIS_AUTH_PORT_6379_TCP_ADDR` — authdb redis hostname
+ * `REDIS_AUTH_PORT_6379_TCP_PORT` — authdb redis port
+ * `REDIS_USERMETA_PORT_6379_TCP_ADDR` — meta redis hostname
+ * `REDIS_USERMETA_PORT_6379_TCP_PORT` — meta redis port
 
-## /usermeta/v1/auth/:token/:key [POST]
+## `GET /:usernames/:keys`
 
-Users' custom data. Valid metadata keys can be restricted using the `USERMETA_VALID_KEYS` environment variable.
+Retrieve publicly available metadata. Both, `:usernames` and `:keys` are comma-separated list. Attach `secret` query string param to retrieve fields up to internal.
 
-Setting `USERMETA_VALID_KEYS` is recommended to prevent people from using your server as free storage. An additional self imposed limitation is that values can't be above 200 bytes.
+Fields that you are not allowed to read will be omitted (as opposed to being HTTP error).
+
+### response [200] OK (application/json)
+
+Suppose `country` is public key and `email` is a protected one.
+
+`GET /alice,bob/country,email` results in following JSON response:
+
+
+``` json
+  { "alice": {"country": "USA"},
+    "bob": {"country": "France"}
+  }
+```
+
+## `GET /auth/:token/:keys`
+
+Retrieve `public`, `protected` and `private` keys for a user with login token equal `:token`. Make `:token` be `"API_SECRET.${username}"` to retrieve fields up to `internal`.
+
+Fields that you are not allowed to read will be omitted (as opposed to being HTTP error).
+
+### response [200] OK (application/json)
+
+Suppose `country` is public key, `email` is a protected one, and `internalId` is internal one.
+
+`GET /auth/alice-auth-token/country,email,internalId` results in following JSON response:
+
+
+``` json
+  { "alice": {
+      "country": "USA",
+      "email": "alice@wonderland.com"
+    }
+  }
+```
+
+### response [401] Not Authorzied
+
+In case of invalid token.
+
+## `POST /auth/:token/:key`
+
+Write `public` and `protected` meta value to a `:key` of a user `:token` points to. Make `:token` be `"API_SECRET.${username}"` to write fields up to `internal` and no byte limit.
 
 ### body (application/json)
 
-    {
-        "value": "..."
-    }
+JSON with single key `"value"` and value being any JSON to write.
 
-(limited to 200 bytes)
-
-### response [200] OK
-
-## /usermeta/v1/auth/:token/:key [GET]
-
-Alias for /usermeta/v1/:username/:key
-
-## /usermeta/v1/:username/:key [GET]
-
-Users' custom data.
-
-### body (application/json)
+``` json
+ { "value": {"something": true}
+ }
+```
 
 ### response [200] OK
+### response [401] Not Authorzied
 
-    {
-        "key": "some-key",
-        "value": "..."
-    }
+In case of invalid token or trying to write `private` and up without `API_SECRET`.
+
+``` json
+ { "restCode": "InvalidCredentialsError",
+   "statusCode": 401,
+   "message": "Invalid credentials"
+ }
+```
+
+### response [413] Payload Too Big
+
+In case of writing `public` or `protected` value of byte size greater than `USERMETA_MAX_LENGTH` env var without `API_SECRET`.
+
+``` json
+ { "restCode": "ValueTooBigError",
+   "statusCode": 413,
+   "message": "Value exceeds ${USERMETA_MAX_LENGTH} byte limit"
+ }
+```

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ Attach metadata to users.
  * `REDIS_USERMETA_PORT_6379_TCP_ADDR` — meta redis hostname
  * `REDIS_USERMETA_PORT_6379_TCP_PORT` — meta redis port
 
-## `GET /:usernames/:keys`
+## `GET /:userIds/:keys`
 
-Retrieve publicly available metadata. Both, `:usernames` and `:keys` are comma-separated list. Attach `secret` query string param to retrieve fields up to internal.
+Retrieve publicly available metadata. Both, `:userIds` and `:keys` are comma-separated list. Attach `secret` query string param to retrieve fields up to internal.
 
 Missing fields and those you are not allowed to read will be omitted (as opposed to being HTTP error).
 
@@ -38,7 +38,7 @@ Suppose `country` is public key and `email` is a protected one.
 
 ## `GET /auth/:token/:keys`
 
-Retrieve `public`, `protected` and `private` keys for a user with login token equal `:token`. Make `:token` be `"API_SECRET.${username}"` to retrieve fields up to `internal`.
+Retrieve `public`, `protected` and `private` keys for a user with login token equal `:token`. Make `:token` be `"API_SECRET.${userId}"` to retrieve fields up to `internal`.
 
 Missing fields and those you are not allowed to read will be omitted (as opposed to being HTTP error).
 
@@ -63,7 +63,7 @@ In case of invalid token.
 
 ## `POST /auth/:token/:key`
 
-Write `public` and `protected` meta value to a `:key` of a user `:token` points to. Make `:token` be `"API_SECRET.${username}"` to write fields up to `internal` and no byte limit.
+Write `public` and `protected` meta value to a `:key` of a user `:token` points to. Make `:token` be `"API_SECRET.${userId}"` to write fields up to `internal` and no byte limit.
 
 ### body (application/json)
 

--- a/README.md
+++ b/README.md
@@ -17,11 +17,20 @@ Attach metadata to users.
  * `REDIS_USERMETA_PORT_6379_TCP_ADDR` — meta redis hostname
  * `REDIS_USERMETA_PORT_6379_TCP_PORT` — meta redis port
 
+Reading and writing different keys requires different access levels:
+
+  * public (read anyone, write token);
+  * protected (read token, write token);
+  * private (read token, write API_SECRET);
+  * internal (read API_SECRET, write API_SECRET).
+
+Keys that are not listed in env vars can't be read or written.
+
 ## `GET /:userIds/:keys`
 
 Retrieve publicly available metadata. Both, `:userIds` and `:keys` are comma-separated list. Attach `secret` query string param to retrieve fields up to internal.
 
-Missing fields and those you are not allowed to read will be omitted (as opposed to being HTTP error).
+Missing or unknown keys, and those you are not allowed to read will be omitted (as opposed to being HTTP error).
 
 ### response [200] OK (application/json)
 
@@ -40,7 +49,7 @@ Suppose `country` is public key and `email` is a protected one.
 
 Retrieve `public`, `protected` and `private` keys for a user with login token equal `:token`. Make `:token` be `"API_SECRET.${userId}"` to retrieve fields up to `internal`.
 
-Missing fields and those you are not allowed to read will be omitted (as opposed to being HTTP error).
+Missing or unknown keys, and those you are not allowed to read will be omitted (as opposed to being HTTP error).
 
 ### response [200] OK (application/json)
 
@@ -77,7 +86,7 @@ JSON with single key `"value"` and value being a string.
 ### response [200] OK
 ### response [401] Not Authorzied
 
-In case of invalid token or trying to write `private` and up without `API_SECRET`.
+In case of invalid token, trying to write `private` and up without `API_SECRET`, or unknown key.
 
 ``` json
  { "restCode": "InvalidCredentialsError",

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Attach metadata to users.
 
 Retrieve publicly available metadata. Both, `:usernames` and `:keys` are comma-separated list. Attach `secret` query string param to retrieve fields up to internal.
 
-Fields that you are not allowed to read will be omitted (as opposed to being HTTP error).
+Missing fields and those you are not allowed to read will be omitted (as opposed to being HTTP error).
 
 ### response [200] OK (application/json)
 
@@ -40,7 +40,7 @@ Suppose `country` is public key and `email` is a protected one.
 
 Retrieve `public`, `protected` and `private` keys for a user with login token equal `:token`. Make `:token` be `"API_SECRET.${username}"` to retrieve fields up to `internal`.
 
-Fields that you are not allowed to read will be omitted (as opposed to being HTTP error).
+Missing fields and those you are not allowed to read will be omitted (as opposed to being HTTP error).
 
 ### response [200] OK (application/json)
 
@@ -67,10 +67,10 @@ Write `public` and `protected` meta value to a `:key` of a user `:token` points 
 
 ### body (application/json)
 
-JSON with single key `"value"` and value being any JSON to write.
+JSON with single key `"value"` and value being a string.
 
 ``` json
- { "value": {"something": true}
+ { "value": "string to write as a meta value"
  }
 ```
 

--- a/config.js
+++ b/config.js
@@ -78,7 +78,7 @@ parseFields.validKeyRegexp = /^[a-z0-9_$]+$/i;
 module.exports = {
   name: pkg.name,
   logLevel: parseLogLevel(process.env.BUNYAN_LEVEL),
-  secret: process.env.hasOwnProperty('API_SECRET') && parseApiSecret(),
+  secret: parseApiSecret(),
 
   fields: global.__ganomedeTest ? {} : {
     public: parseFields('USERMETA_PUBLIC_KEYS'),

--- a/config.js
+++ b/config.js
@@ -97,12 +97,12 @@ module.exports = {
   },
 
   redisAuthdb: {
-    hostname: ServiceEnv.host('REDIS_AUTH', 6379),
+    host: ServiceEnv.host('REDIS_AUTH', 6379),
     port: ServiceEnv.port('REDIS_AUTH', 6379)
   },
 
   redisUsermeta: {
-    hostname: ServiceEnv.host('REDIS_USERMETA', 6379),
+    host: ServiceEnv.host('REDIS_USERMETA', 6379),
     port: ServiceEnv.port('REDIS_USERMETA', 6379)
   }
 };

--- a/config.js
+++ b/config.js
@@ -7,7 +7,7 @@ const pkg = require('./package.json');
 
 const parseLogLevel = (envValue) => {
   const defaultLevel = 'INFO';
-  const desiredLevel = envValue ? String(envValue) : defaultLevel;
+  const desiredLevel = envValue ? String(envValue).toUpperCase() : defaultLevel;
   const levels = [
     'FATAL',
     'ERROR',
@@ -77,7 +77,7 @@ parseFields.validKeyRegexp = /^[a-z0-9_$]+$/i;
 
 module.exports = {
   name: pkg.name,
-  logLevel: parseLogLevel(process.env.BUNYAN_LEVEL),
+  logLevel: parseLogLevel(process.env.LOG_LEVEL),
   secret: parseApiSecret(),
 
   fields: global.__ganomedeTest ? {} : {

--- a/index.js
+++ b/index.js
@@ -2,11 +2,11 @@
 
 // Use New Relic if LICENSE_KEY has been specified.
 if (process.env.NEW_RELIC_LICENSE_KEY) {
-    if (!process.env.NEW_RELIC_APP_NAME) {
-        var pk = require('./package.json');
-        process.env.NEW_RELIC_APP_NAME = pk.api;
-    }
-    require('newrelic');
+  if (!process.env.NEW_RELIC_APP_NAME) {
+    const pk = require('./package.json');
+    process.env.NEW_RELIC_APP_NAME = pk.api;
+  }
+  require('newrelic');
 }
 
 const async = require('async');

--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ const child = () => {
 
   // Handle uncaughtException, kill the worker.
   server.on('uncaughtException', (req, res, route, err) => {
-    logger.error(err);
+    logger.fatal(err);
 
     // Note: we're in dangerous territory!
     // By definition, something unexpected occurred,
@@ -94,7 +94,7 @@ const child = () => {
       res.send(new restify.InternalError(message));
     }
     catch (err2) {
-      logger.error(err2, 'error sending 500!');
+      logger.fatal(err2, 'error sending 500!');
     }
   });
 };

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ const curtain = require('curtain-down');
 const config = require('./config');
 const about = require('./src/about.router');
 const ping = require('./src/ping.router');
+const usermeta = require('./src/usermeta.router');
 const createServer = require('./src/server');
 const logger = require('./src/logger');
 
@@ -62,6 +63,7 @@ const child = () => {
 
   about(config.http.prefix, server);
   ping(config.http.prefix, server);
+  usermeta()(config.http.prefix, server);
 
   server.listen(config.http.port, config.http.host, () => {
     const {port, family, address} = server.address();

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "start": "node index.js",
     "startw": "nodemon --watch src/ --watch index.js --watch config.js --exec 'npm start'",
-    "test": "BUNYAN_LEVEL=ERROR mocha --bail --no-exit --throw-deprecation tests/helper.js 'tests/**/*.test.js'",
+    "test": "API_SECRET=api_secret BUNYAN_LEVEL=ERROR mocha --bail --no-exit --throw-deprecation tests/helper.js 'tests/**/*.test.js'",
     "testw": "nodemon --watch src/ --watch tests/ --watch config.js --exec 'npm test'",
     "lint": "eslint src/ tests/ index.js config.js"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "usermeta",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "private": true,
   "api": "usermeta/v1",
   "description": "usermeta microservice",
@@ -8,7 +8,7 @@
   "scripts": {
     "start": "node index.js",
     "startw": "nodemon --watch src/ --watch index.js --watch config.js --exec 'npm start'",
-    "test": "API_SECRET=api_secret BUNYAN_LEVEL=ERROR mocha --bail --no-exit --throw-deprecation tests/helper.js 'tests/**/*.test.js'",
+    "test": "API_SECRET=api_secret LOG_LEVEL=error mocha --bail --no-exit --throw-deprecation tests/helper.js 'tests/**/*.test.js'",
     "testw": "nodemon --watch src/ --watch tests/ --watch config.js --exec 'npm test'",
     "lint": "eslint src/ tests/ index.js config.js"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "usermeta",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "private": true,
   "api": "usermeta/v1",
   "description": "usermeta microservice",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "usermeta",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "private": true,
   "api": "usermeta/v1",
   "description": "usermeta microservice",

--- a/src/fields/Db.js
+++ b/src/fields/Db.js
@@ -5,9 +5,6 @@ class Db {
     this.redis = redisClient;
   }
 
-  // Note how this does not parse JSON.
-  // We do so in Formatter, because that way we can distinguish between
-  // missing redis keys and redis key set to null.
   getKeys (keys, callback) {
     return (keys.length === 0)
       ? setImmediate(callback, null, [])
@@ -17,11 +14,8 @@ class Db {
   setKeys (keys, values, callback) {
     const args = [];
 
-    for (let index = 0; index < keys.length; ++index) {
-      const key = keys[index];
-      const value = JSON.stringify(values[index]);
-      args.push(key, value);
-    }
+    for (let index = 0; index < keys.length; ++index)
+      args.push(keys[index], values[index]);
 
     return this.redis.mset(args, callback);
   }

--- a/src/fields/Formatter.js
+++ b/src/fields/Formatter.js
@@ -1,7 +1,7 @@
 'use strict';
 
 //
-// Formatter class converts (usernames, metanames) to database keys, back an forth.
+// Formatter class converts (userIds, metanames) to database keys, back an forth.
 //
 
 const toArray = (thing) => {
@@ -18,25 +18,25 @@ const crossJoin = (left, right) => {
 };
 
 class Formatter {
-  static toKeys (usernames, metanames) {
+  static toKeys (userIds, metanames) {
     return crossJoin(
-      toArray(usernames),
+      toArray(userIds),
       toArray(metanames)
     );
   }
 
-  static toResult (usernames, keys = [], values = []) {
-    const result = toArray(usernames).reduce((ref, username) => {
-      ref[username] = {};
+  static toResult (userIds, keys = [], values = []) {
+    const result = toArray(userIds).reduce((ref, userId) => {
+      ref[userId] = {};
       return ref;
     }, {});
 
     keys.forEach((key, index) => {
-      const [username, metaname] = key.split(':');
+      const [userId, metaname] = key.split(':');
       const value = values[index];
 
       if (value !== null)
-        result[username][metaname] = value;
+        result[userId][metaname] = value;
     });
 
     return result;

--- a/src/fields/Formatter.js
+++ b/src/fields/Formatter.js
@@ -25,18 +25,21 @@ class Formatter {
     );
   }
 
-  static toResult (keys, values) {
-    return keys && values && keys.reduce((ref, key, index) => {
-      const value = values[index];
-
-      if (value !== null) {
-        const [username, metaname] = key.split(':');
-        ref[username] = ref[username] || {};
-        ref[username][metaname] = JSON.parse(value);
-      }
-
+  static toResult (usernames, keys = [], values = []) {
+    const result = toArray(usernames).reduce((ref, username) => {
+      ref[username] = {};
       return ref;
     }, {});
+
+    keys.forEach((key, index) => {
+      const [username, metaname] = key.split(':');
+      const value = values[index];
+
+      if (value !== null)
+        result[username][metaname] = value;
+    });
+
+    return result;
   }
 }
 

--- a/src/fields/ReadWrite.js
+++ b/src/fields/ReadWrite.js
@@ -22,21 +22,21 @@ class ReadWrite {
     this.db = new Db({redisClient});
   }
 
-  read (level, usernames, metadatas, callback) {
+  read (level, userIds, metadatas, callback) {
     const readables = this.filter.readable(level, metadatas);
-    const keys = Formatter.toKeys(usernames, readables);
+    const keys = Formatter.toKeys(userIds, readables);
 
     this.db.getKeys(keys, (err, values) =>
-      callback(err, Formatter.toResult(usernames, keys, values)));
+      callback(err, Formatter.toResult(userIds, keys, values)));
   }
 
-  write (level, username, metadata, value, callback) {
+  write (level, userId, metadata, value, callback) {
     const writable = this.filter.writable(level, metadata, value);
     if (writable instanceof Error)
       return setImmediate(callback, writable);
 
     this.db.setKeys(
-      Formatter.toKeys(username, metadata),
+      Formatter.toKeys(userId, metadata),
       [value],
       callback
     );

--- a/src/fields/ReadWrite.js
+++ b/src/fields/ReadWrite.js
@@ -27,7 +27,7 @@ class ReadWrite {
     const keys = Formatter.toKeys(usernames, readables);
 
     this.db.getKeys(keys, (err, values) =>
-      callback(err, Formatter.toResult(keys, values)));
+      callback(err, Formatter.toResult(usernames, keys, values)));
   }
 
   write (level, username, metadata, value, callback) {

--- a/src/fields/levels.js
+++ b/src/fields/levels.js
@@ -5,11 +5,8 @@
 class Levels {
   // There are no `protected` access level.
   static parse ({secretMatches, username}) {
-    if (secretMatches) {
-      return username
-        ? Levels.internal
-        : Levels.public;
-    }
+    if (secretMatches)
+      return Levels.internal;
 
     return username
       ? Levels.private

--- a/src/fields/levels.js
+++ b/src/fields/levels.js
@@ -4,11 +4,11 @@
 
 class Levels {
   // There are no `protected` access level.
-  static parse ({secretMatches, username}) {
+  static parse ({secretMatches, userId}) {
     if (secretMatches)
       return Levels.internal;
 
-    return username
+    return userId
       ? Levels.private
       : Levels.public;
   }

--- a/src/middlewares.js
+++ b/src/middlewares.js
@@ -11,7 +11,7 @@ const requireSecret = (req, res, next) => {
     : sendHttpError(next, new InvalidCredentialsError());
 };
 
-const parseUsernameFromSecretToken = (secret, token) => {
+const parseUserIdFromSecretToken = (secret, token) => {
   return secret && token && token.startsWith(secret) && (token.length > secret.length + 1)
     ? token.slice(secret.length + 1)
     : false;
@@ -22,10 +22,10 @@ const requireAuth = ({authdbClient, secret = false, paramName = 'token'} = {}) =
   if (!token)
     return sendHttpError(next, new InvalidAuthTokenError());
 
-  const spoofed = secret && parseUsernameFromSecretToken(secret, token);
+  const spoofed = secret && parseUserIdFromSecretToken(secret, token);
   if (spoofed) {
     req.ganomede.secretMatches = true;
-    req.ganomede.username = spoofed;
+    req.ganomede.userId = spoofed;
     return next();
   }
 
@@ -41,14 +41,14 @@ const requireAuth = ({authdbClient, secret = false, paramName = 'token'} = {}) =
     // Authdb already JSON.parsed redisResult for us,
     // but sometimes it is a string with user id,
     // and sometimes it is account object with {username, email, etc...}
-    const username = (typeof redisResult === 'string')
+    const userId = (typeof redisResult === 'string')
       ? redisResult
-      : redisResult.username;
+      : redisResult.username; // userId used to be username from profile
 
     if (!redisResult)
       return sendHttpError(next, new InvalidCredentialsError());
 
-    req.ganomede.username = username;
+    req.ganomede.userId = userId;
     return next();
   });
 };

--- a/src/usermeta.router.js
+++ b/src/usermeta.router.js
@@ -67,7 +67,7 @@ module.exports = ({
       requireAuth, parseLevel, parseCsvParam('metanames'), readMetas('username'));
 
     server.post(`${prefix}/auth/:token/:metaname`, requireAuth, parseLevel, (req, res, next) => {
-      if (!(req.body && hasOwnProperty(req.body, 'value')))
+      if (!(req.body && hasOwnProperty(req.body, 'value') && (typeof req.body.value === 'string')))
         return sendHttpError(next, new RequestValidationError('InvalidValue', 'Invalid value'));
 
       readWrite.write(

--- a/src/usermeta.router.js
+++ b/src/usermeta.router.js
@@ -54,8 +54,9 @@ module.exports = ({
   const readMetas = (usernamesKey) => (req, res, next) => {
     const {accessLevel, metanames} = req.ganomede;
     const usernames = req.ganomede[usernamesKey];
-    readWrite.read(accessLevel, usernames, metanames, (err, result) =>
-      err ? sendHttpError(next, err) : res.json(result));
+    readWrite.read(accessLevel, usernames, metanames, (err, result) => {
+      return err ? sendHttpError(next, err) : res.json(result);
+    });
   };
 
   return (prefix, server) => {

--- a/src/usermeta.router.js
+++ b/src/usermeta.router.js
@@ -45,8 +45,10 @@ module.exports = ({
 
   const parseCsvParam = (paramKey) => (req, res, next) => {
     const values = normalizeCSV(req.params, paramKey);
+
     if (values instanceof Error)
       return sendHttpError(next, values);
+
     req.ganomede[paramKey] = values;
     next();
   };
@@ -55,7 +57,11 @@ module.exports = ({
     const {accessLevel, metanames} = req.ganomede;
     const usernames = req.ganomede[usernamesKey];
     readWrite.read(accessLevel, usernames, metanames, (err, result) => {
-      return err ? sendHttpError(next, err) : res.json(result);
+      if (err)
+        return sendHttpError(next, err);
+
+      res.json(result);
+      next();
     });
   };
 
@@ -76,9 +82,11 @@ module.exports = ({
         req.params.metaname,
         req.body.value,
         (err) => {
-          return err
-            ? sendHttpError(next, err)
-            : res.json({});
+          if (err)
+            return sendHttpError(next, err);
+
+          res.json({});
+          next();
         }
       );
     });

--- a/src/usermeta.router.js
+++ b/src/usermeta.router.js
@@ -10,7 +10,7 @@ const {hasOwnProperty} = require('./utils');
 const config = require('../config');
 
 module.exports = ({
-  secret,
+  secret = config.secret,
   authdbClient = authdb.createClient(config.redisAuthdb),
   readWrite = new ReadWrite({
     redisClient: redis.createClient(config.redisUsermeta),

--- a/src/usermeta.router.js
+++ b/src/usermeta.router.js
@@ -53,10 +53,10 @@ module.exports = ({
     next();
   };
 
-  const readMetas = (usernamesKey) => (req, res, next) => {
+  const readMetas = (userIdsKey) => (req, res, next) => {
     const {accessLevel, metanames} = req.ganomede;
-    const usernames = req.ganomede[usernamesKey];
-    readWrite.read(accessLevel, usernames, metanames, (err, result) => {
+    const userIds = req.ganomede[userIdsKey];
+    readWrite.read(accessLevel, userIds, metanames, (err, result) => {
       if (err)
         return sendHttpError(next, err);
 
@@ -66,11 +66,11 @@ module.exports = ({
   };
 
   return (prefix, server) => {
-    server.get(`${prefix}/:usernames/:metanames`,
-      parseLevel, parseCsvParam('usernames'), parseCsvParam('metanames'), readMetas('usernames'));
+    server.get(`${prefix}/:userIds/:metanames`,
+      parseLevel, parseCsvParam('userIds'), parseCsvParam('metanames'), readMetas('userIds'));
 
     server.get(`${prefix}/auth/:token/:metanames`,
-      requireAuth, parseLevel, parseCsvParam('metanames'), readMetas('username'));
+      requireAuth, parseLevel, parseCsvParam('metanames'), readMetas('userId'));
 
     server.post(`${prefix}/auth/:token/:metaname`, requireAuth, parseLevel, (req, res, next) => {
       if (!(req.body && hasOwnProperty(req.body, 'value') && (typeof req.body.value === 'string')))
@@ -78,7 +78,7 @@ module.exports = ({
 
       readWrite.write(
         req.ganomede.accessLevel,
-        req.ganomede.username,
+        req.ganomede.userId,
         req.params.metaname,
         req.body.value,
         (err) => {

--- a/tests/fields/Db.test.js
+++ b/tests/fields/Db.test.js
@@ -27,13 +27,13 @@ describe('Db', () => {
     });
   });
 
-  it('#setKeys() calls mset with JSON strings', (done) => {
+  it('#setKeys() calls mset with strings', (done) => {
     const redisClient = td.object(['mset']);
     const db = new Db({redisClient});
-    const keys = ['a', 'b', 'c', 'd'];
-    const values = [null, {x: true}, 3, ['f']];
+    const keys = ['a', 'b'];
+    const values = ['some val', 'too dreamy'];
 
-    td.when(redisClient.mset(['a', 'null', 'b', '{"x":true}', 'c', '3', 'd', '["f"]'], td.callback))
+    td.when(redisClient.mset(['a', 'some val', 'b', 'too dreamy'], td.callback))
       .thenCallback(null, 'OK');
 
     db.setKeys(keys, values, (err, reply) => {

--- a/tests/fields/Formatter.test.js
+++ b/tests/fields/Formatter.test.js
@@ -4,25 +4,25 @@ const Formatter = require('../../src/fields/Formatter');
 
 describe('Formatter', () => {
   describe('.toKeys()', () => {
-    it('converts single username and single meta', () => {
+    it('converts single userId and single meta', () => {
       expect(Formatter.toKeys('alice', 'country')).to.eql(['alice:country']);
     });
 
-    it('converts multiple usernames and single meta', () => {
+    it('converts multiple userIds and single meta', () => {
       expect(Formatter.toKeys(['alice', 'bob'], ['country'])).to.eql([
         'alice:country',
         'bob:country'
       ]);
     });
 
-    it('converts single username and multiple metas', () => {
+    it('converts single userId and multiple metas', () => {
       expect(Formatter.toKeys(['alice'], ['country', 'email'])).to.eql([
         'alice:country',
         'alice:email'
       ]);
     });
 
-    it('converts multiple usernames and multiple metas', () => {
+    it('converts multiple userIds and multiple metas', () => {
       expect(Formatter.toKeys(['alice', 'bob'], ['country', 'email'])).to.eql([
         'alice:country',
         'alice:email',
@@ -31,7 +31,7 @@ describe('Formatter', () => {
       ]);
     });
 
-    it('empty usernames mean empty keys', () => {
+    it('empty userIds mean empty keys', () => {
       expect(Formatter.toKeys([], ['x', 'y'])).to.eql([]);
     });
 
@@ -78,7 +78,7 @@ describe('Formatter', () => {
       });
     });
 
-    it('outputs empty object for usernames with no metas', () => {
+    it('outputs empty object for userIds with no metas', () => {
       expect(Formatter.toResult(['alice'], ['alice:missing'], [null])).to.eql({alice: {}});
     });
   });

--- a/tests/fields/Formatter.test.js
+++ b/tests/fields/Formatter.test.js
@@ -54,9 +54,9 @@ describe('Formatter', () => {
         'alice@example.com',
         'Russia',
         'bob@example.com'
-      ].map(val => JSON.stringify(val));
+      ];
 
-      expect(Formatter.toResult(keys, values)).to.eql({
+      expect(Formatter.toResult(['alice', 'bob'], keys, values)).to.eql({
         alice: {
           country: 'USA',
           email: 'alice@example.com'
@@ -69,19 +69,17 @@ describe('Formatter', () => {
       });
     });
 
-    it('supports keys explicitly set as null', () => {
-      const keys = ['alice:country', 'alice:explicit_null'];
-      const values = ['"USA"', 'null'];
-      expect(Formatter.toResult(keys, values)).to.eql({alice: {
-        country: 'USA',
-        explicit_null: null
-      }});
-    });
-
     it('missing redis keys are not included to result', () => {
       const keys = ['alice:country', 'alice:email'];
-      const values = ['"USA"', null];
-      expect(Formatter.toResult(keys, values)).to.eql({alice: {country: 'USA'}});
+      const values = ['USA', null];
+      expect(Formatter.toResult(['alice', 'bob'], keys, values)).to.eql({
+        alice: {country: 'USA'},
+        bob: {}
+      });
+    });
+
+    it('outputs empty object for usernames with no metas', () => {
+      expect(Formatter.toResult(['alice'], ['alice:missing'], [null])).to.eql({alice: {}});
     });
   });
 });

--- a/tests/fields/levels.test.js
+++ b/tests/fields/levels.test.js
@@ -15,12 +15,12 @@ describe('levels', () => {
     expect(parse({secretMatches: false})).to.equal(levels.public);
   });
 
-  it('public — secret without username makes no sense', () => {
-    expect(parse({secretMatches: true})).to.equal(levels.public);
-  });
-
   it('private — username but no secret', () => {
     expect(parse({secretMatches: false, username: 'joe'})).to.equal(levels.private);
+  });
+
+  it('internal — secret without username', () => {
+    expect(parse({secretMatches: true})).to.equal(levels.internal);
   });
 
   it('internal — username and secret', () => {

--- a/tests/fields/levels.test.js
+++ b/tests/fields/levels.test.js
@@ -11,19 +11,19 @@ describe('levels', () => {
     expect(levels.internal).to.be.greaterThan(levels.private);
   });
 
-  it('public — no username and no secret', () => {
+  it('public — no userId and no secret', () => {
     expect(parse({secretMatches: false})).to.equal(levels.public);
   });
 
-  it('private — username but no secret', () => {
-    expect(parse({secretMatches: false, username: 'joe'})).to.equal(levels.private);
+  it('private — userId but no secret', () => {
+    expect(parse({secretMatches: false, userId: 'joe'})).to.equal(levels.private);
   });
 
-  it('internal — secret without username', () => {
+  it('internal — secret without userId', () => {
     expect(parse({secretMatches: true})).to.equal(levels.internal);
   });
 
-  it('internal — username and secret', () => {
-    expect(parse({secretMatches: true, username: 'joe'})).to.equal(levels.internal);
+  it('internal — userId and secret', () => {
+    expect(parse({secretMatches: true, userId: 'joe'})).to.equal(levels.internal);
   });
 });

--- a/tests/middlewares.test.js
+++ b/tests/middlewares.test.js
@@ -33,7 +33,7 @@ describe('Middlewares', () => {
 
       mw(req, {}, (err) => {
         expect(err).to.not.be.ok;
-        expect(req.ganomede).to.have.property('username', 'user');
+        expect(req.ganomede).to.have.property('userId', 'user');
         expect(req.ganomede).to.not.have.property('secretMatches');
         done();
       });
@@ -47,7 +47,7 @@ describe('Middlewares', () => {
 
       mw(req, {}, (err) => {
         expect(err).to.not.be.ok;
-        expect(req.ganomede).to.have.property('username', 'user');
+        expect(req.ganomede).to.have.property('userId', 'user');
         expect(req.ganomede).to.have.property('secretMatches', true);
         done();
       });

--- a/tests/usermeta.router.test.js
+++ b/tests/usermeta.router.test.js
@@ -33,6 +33,7 @@ describe('usermeta.router', () => {
     .mset([
       // tokens
       'alice_token', '"alice"',
+      'bob_token', JSON.stringify({username: 'bob'}),
       // some metdata
       'alice:country', 'USA',
       'alice:email', 'alice@example.com',
@@ -100,14 +101,14 @@ describe('usermeta.router', () => {
   describe('POST /auth/:token/:metaname', () => {
     it('works with token', (done) => {
       go()
-        .post('/auth/alice_token/email')
-        .send({value: 'new-alice@example.com'})
+        .post('/auth/bob_token/email')
+        .send({value: 'new-bob@example.com'})
         .expect(200)
         .end((err, res) => {
           expect(err).to.be.null;
-          redisClient.get('alice:email', (err, val) => {
+          redisClient.get('bob:email', (err, val) => {
             expect(err).to.be.null;
-            expect(val).to.equal('new-alice@example.com');
+            expect(val).to.equal('new-bob@example.com');
             done();
           });
         });

--- a/tests/usermeta.router.test.js
+++ b/tests/usermeta.router.test.js
@@ -47,7 +47,7 @@ describe('usermeta.router', () => {
   after(done => redisClient.flushdb(done));
   after(done => redisClient.quit(done));
 
-  describe('GET /:usernames/:metanames', () => {
+  describe('GET /:userIds/:metanames', () => {
     it('works for public fields', (done) => {
       go()
         .get('/alice,bob/country,email,key,no_one_has_this_one')

--- a/tests/usermeta.router.test.js
+++ b/tests/usermeta.router.test.js
@@ -34,12 +34,11 @@ describe('usermeta.router', () => {
       // tokens
       'alice_token', '"alice"',
       // some metdata
-      'alice:country', '"USA"',
-      'alice:email', '"alice@example.com"',
-      'alice:key', '"alice-key"',
-      'bob:country', '"Russia"',
-      'bob:email', '"bob@example.com"',
-      'bob:key', 'null',
+      'alice:country', 'USA',
+      'alice:email', 'alice@example.com',
+      'alice:key', 'alice-key',
+      'bob:country', 'Russia',
+      'bob:email', 'bob@example.com'
     ])
     .exec(done)
   );
@@ -63,6 +62,15 @@ describe('usermeta.router', () => {
         .query({secret: 'api_secret'})
         .expect(200, {alice: {email: 'alice@example.com'}}, done);
     });
+
+    it('empty objects', (done) => {
+      go()
+        .get('/alice,some-random-guy/no-such-field')
+        .expect(200, {
+          alice: {},
+          'some-random-guy': {}
+        }, done);
+    });
   });
 
   describe('GET /auth/:token/:metanames', () => {
@@ -83,8 +91,7 @@ describe('usermeta.router', () => {
         .expect(200, {
           bob: {
             country: 'Russia',
-            email: 'bob@example.com',
-            key: null
+            email: 'bob@example.com'
           },
         }, done);
     });
@@ -100,7 +107,7 @@ describe('usermeta.router', () => {
           expect(err).to.be.null;
           redisClient.get('alice:email', (err, val) => {
             expect(err).to.be.null;
-            expect(val).to.equal('"new-alice@example.com"');
+            expect(val).to.equal('new-alice@example.com');
             done();
           });
         });
@@ -115,7 +122,7 @@ describe('usermeta.router', () => {
           expect(err).to.be.null;
           redisClient.get('bob:key', (err, val) => {
             expect(err).to.be.null;
-            expect(val).to.equal('"bob-key"');
+            expect(val).to.equal('bob-key');
             done();
           });
         });

--- a/tests/usermeta.router.test.js
+++ b/tests/usermeta.router.test.js
@@ -56,6 +56,13 @@ describe('usermeta.router', () => {
           bob: {country: 'Russia'}
         }, done);
     });
+
+    it('secret works', (done) => {
+      go()
+        .get('/alice/email')
+        .query({secret: 'api_secret'})
+        .expect(200, {alice: {email: 'alice@example.com'}}, done);
+    });
   });
 
   describe('GET /auth/:token/:metanames', () => {


### PR DESCRIPTION
- [x] allow strings only as values;
- [x] when no keys are found for username, return empty object anyways (`{"missing-user": {}}` instead of `{}`);
- [x] always call `next()`;
- [x] `GET /:usernames/:keys` accepts `secret` QS param;
- [x] fix authdb middleware to expect JSON object sometimes.

Also renamed `username(s)` to `userId(s)` (so it is `req.ganomede.userId`) — less confusing?